### PR TITLE
Fix: Timeout of the tag

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -119,17 +119,14 @@ addEventCallback((containerId, eventData) => {
   if (data.projectId == undefined) {
     log('Missing project ID.');
     skipWrite = true;
-    data.gtmOnFailure();
   }
   if (data.datasetId == undefined) {
     log('Missing dataset ID.');
     skipWrite = true;
-    data.gtmOnFailure();
   }
   if (data.tableId == undefined) {
     log('Missing table ID.');
     skipWrite = true;
-    data.gtmOnFailure();
   }
 
   if (skipWrite) {
@@ -241,17 +238,16 @@ addEventCallback((containerId, eventData) => {
           data.measurementId == '*') && consented) {
         BigQuery.insert(connectionInfo, rows, options)
           .then((success) => {
-            data.gtmOnSuccess();
+            log('success');
           }, (e) => {
             log(JSON.stringify(e));
-            data.gtmOnFailure();
           });
-      } else {
-        data.gtmOnSuccess();
       }
     }
   }
 });
+
+data.gtmOnSuccess();
 
 
 ___SERVER_PERMISSIONS___


### PR DESCRIPTION
Hey!

When using the `addEventCallback` function, as it waits for all tags to be done, the `data.gtmOnSuccess` must be called synchrnously, else the client will hold for the tag to timeout.

For example:
![image](https://user-images.githubusercontent.com/5872952/173027806-7a9250e2-3051-4bcb-9ce6-4c9fd528de0d.png)

We _could_ let the `data.gtmOnFailure` / `data.gtmOnSuccess`, however as far as I tested, it doesn't change anything.