### PR TITLE
Fix: Add UserAgent Column to Schema

### DIFF
--- a/sgtm_ga4_to_bigquery_schema.json
+++ b/sgtm_ga4_to_bigquery_schema.json
@@ -9,6 +9,11 @@
     "name":"ip_address",
     "type":"STRING"
   },
+  {
+    "mode":"NULLABLE",
+    "name":"user_agent",
+    "type":"STRING"
+  },
 	{
     "mode":"NULLABLE",
     "name":"gclid",


### PR DESCRIPTION
Hey!

The `user_agent` is added to the `row` variables in the template, however it isn't in the schema file provided.