### PR TITLE
Feature: Add event_timestamp

### DIFF
--- a/sgtm_ga4_to_bigquery_schema.json
+++ b/sgtm_ga4_to_bigquery_schema.json
@@ -1,6 +1,11 @@
 [
   {
     "mode":"NULLABLE",
+    "name":"event_timestamp",
+    "type":"TIMESTAMP"
+  },
+  {
+    "mode":"NULLABLE",
     "name":"measurement_id",
     "type":"STRING"
   },

--- a/template.tpl
+++ b/template.tpl
@@ -113,6 +113,7 @@ const getRemoteAddress = require('getRemoteAddress');
 const getRequestHeader = require('getRequestHeader');
 const extractEventsFromMpv2 = require('extractEventsFromMpv2');
 const getRequestQueryParameters = require('getRequestQueryParameters');
+const getTimestampMillis = require('getTimestampMillis');
 
 addEventCallback((containerId, eventData) => {
   let skipWrite = false;
@@ -133,6 +134,7 @@ addEventCallback((containerId, eventData) => {
     // Check event is GA4
     if (isRequestMpv2()) {
       const rows = extractEventsFromMpv2();
+      rows[0].event_timestamp = getTimestampMillis() / 1000
       rows[0].event_params = [];
       rows[0].user_properties = [];
       rows[0].user_agent = getRequestHeader('user-agent');


### PR DESCRIPTION
Closes #5

As it was not present at the time, I'm not sure if this is something that we always want, so I could add a configuration to chose whether to add it?

One thing we could do as well is to make the `event_timestamp` the partition column instead of ingestion, but this would mean changing a few more things, let me know!