### PR TITLE
fix: avoid having user_properties overriden

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -217,6 +217,11 @@ addEventCallback((containerId, eventData) => {
         newParam = newParam.replace('x_ga_', '');
         newParam = newParam.replace('mp2_', '');
         newParam = newParam.replace('utm_', '');
+        
+        if (newParam === 'user_properties') {
+          continue;
+        }
+        
         rows[0][newParam] = rows[0][param];
       }
       rows[0].session_engagement = rows[0].seg;


### PR DESCRIPTION
Hi!

When sending user_properties to sGTM, there was an issue where `user_properties` were set twice:

- Once https://github.com/google/sgtm-ga4-to-bigquery/blob/main/template.tpl#L180 when reading from `getRequestQueryParameters`, and setting the `user_properties` as the BigQuery was expecting it (an array of object)
- A second time when looping over every key in rows, and it was getting the `x-ga-mp2-user_properties` key, and copying this value to the `user_properties`.

This was making `user_properties` as an object, but bigquery is expecting an array.